### PR TITLE
Fixing cert verification bugs

### DIFF
--- a/go-server-server/go/logger.go
+++ b/go-server-server/go/logger.go
@@ -45,7 +45,7 @@ func InitLogging() {
 }
 
 func CommonNameMatch(r *http.Request) bool {
-    commonName := r.TLS.VerifiedChains[0][0].Subject.CommonName
+    commonName := r.TLS.PeerCertificates[0].Subject.CommonName
 
     //FIXME : in the authentication of client certificate,  after the certificate chain is validated by 
     // TLS, here we will futher check if the common name of the end-entity certificate is in the trusted 

--- a/go-server-server/main.go
+++ b/go-server-server/main.go
@@ -41,7 +41,9 @@ func StartHttpsServer(handler http.Handler) {
         // VerifyClientCertIfGiven
         // RequireAndVerifyClientCert
         ClientAuth: tls.RequireAndVerifyClientCert,
+        MinVersion: tls.VersionTLS12,
     }
+
     tlsConfig.BuildNameToCertificate()
 
     server := &http.Server{

--- a/supervisor/rest_api.conf
+++ b/supervisor/rest_api.conf
@@ -1,5 +1,5 @@
 [program:rest-api]
-command=/usr/sbin/go-server-server -enablehttps=true -clientcert=/usr/sbin/cert/client/selfsigned.crt -servercert=/usr/sbin/cert/server/selfsigned.crt -serverkey=/usr/sbin/cert/server/selfsigned.key -loglevel trace
+command=/usr/sbin/go-server-server -enablehttps=true -clientcert=/usr/sbin/cert/client/selfsigned.crt -servercert=/usr/sbin/cert/server/selfsigned.crt -serverkey=/usr/sbin/cert/server/selfsigned.key -clientcertcommonname=client.restapi.sonic.gbl -loglevel trace
 priority=1
 autostart=true
 autorestart=false


### PR DESCRIPTION
1. Set minimum TLS version to 1.2
2. Fix bugs in verifying common name field in the certificate