### PR TITLE
Refactoring Authentication code

### DIFF
--- a/go-server-server/go/auth.go
+++ b/go-server-server/go/auth.go
@@ -1,0 +1,24 @@
+package mseeserver
+
+import (
+    "log"
+    "net/http"
+)
+
+func CommonNameMatch(r *http.Request) bool {
+    //FIXME : in the authentication of client certificate,  after the certificate chain is validated by 
+    // TLS, here we will futher check if the common name of the end-entity certificate is in the trusted 
+	// common name list of the server config. A more strict check may be added here later.
+	for _, peercert := range r.TLS.PeerCertificates {
+		commonName := peercert.Subject.CommonName
+		for _, name := range trustedertCommonNames {
+			if commonName == name {
+				return true;
+			}
+		}
+		log.Printf("info: CommonName in the client cert: %s", commonName)
+	}
+
+    log.Printf("error: Authentication Fail! None of the CommonNames in the client cert are found in trusted common names")
+    return false;
+}

--- a/go-server-server/go/logger.go
+++ b/go-server-server/go/logger.go
@@ -43,19 +43,3 @@ func InitLogging() {
     }
     colog.SetOutput(file)
 }
-
-func CommonNameMatch(r *http.Request) bool {
-    commonName := r.TLS.PeerCertificates[0].Subject.CommonName
-
-    //FIXME : in the authentication of client certificate,  after the certificate chain is validated by 
-    // TLS, here we will futher check if the common name of the end-entity certificate is in the trusted 
-    // common name list of the server config. A more strict check may be added here later.
-    for _, name := range trustedertCommonNames {
-        if commonName == name {
-            return true;
-        }
-    }
-
-    log.Printf("error: Authentication Fail! CommonName in the client cert: %s is not found in trusted common names", commonName)
-    return false;
-}

--- a/supervisor/rest_api.conf
+++ b/supervisor/rest_api.conf
@@ -1,5 +1,5 @@
 [program:rest-api]
-command=/usr/sbin/go-server-server -enablehttps=true -clientcert=/usr/sbin/cert/client/selfsigned.crt -servercert=/usr/sbin/cert/server/selfsigned.crt -serverkey=/usr/sbin/cert/server/selfsigned.key -clientcertcommonname=client.restapi.sonic.gbl -loglevel trace
+command=/usr/sbin/go-server-server -enablehttps=true -clientcert=/usr/sbin/cert/client/selfsigned.crt -servercert=/usr/sbin/cert/server/selfsigned.crt -serverkey=/usr/sbin/cert/server/selfsigned.key -loglevel trace
 priority=1
 autostart=true
 autorestart=false


### PR DESCRIPTION
1. Moving authentication to a separate file
2. Checking for common name match from all the peercertificates presented