### PR TITLE
Enable proxy_arp setting for Vnet interfaces

### DIFF
--- a/go-server-server/go/default.go
+++ b/go-server-server/go/default.go
@@ -214,6 +214,7 @@ func ConfigInterfaceVlanPost(w http.ResponseWriter, r *http.Request) {
         vnet_id_str = VNET_NAME_PREF + strconv.FormatUint(uint64(vnet_id), 10)
         vlan_if_pt.Set(vlan_name, map[string]string{
             "vnet_name": vnet_id_str,
+            "proxy_arp": "enabled",
         }, "SET", "")
     }
 

--- a/test/apitest.py
+++ b/test/apitest.py
@@ -450,7 +450,7 @@ class ra_client_positive_tests(rest_api_client):
         vlan_table = self.configdb.hgetall(VLAN_TB + '|' + VLAN_NAME_PREF + '2')
         self.assertEqual(vlan_table, {b'vlanid': b'2'})
         vlan_intf_table = self.configdb.hgetall(VLAN_INTF_TB + '|' + VLAN_NAME_PREF + '2')
-        self.assertEqual(vlan_intf_table, {b'vnet_name': VNET_NAME_PREF + '1'})
+        self.assertEqual(vlan_intf_table, {b'proxy_arp': b'enabled', b'vnet_name': VNET_NAME_PREF + '1'})
 
         # delete
         r = self.delete_config_vlan(2)
@@ -508,7 +508,7 @@ class ra_client_positive_tests(rest_api_client):
         vlan_intf_table = self.configdb.hgetall(VLAN_INTF_TB + '|' + VLAN_NAME_PREF + '2|10.0.1.1/24')
         self.assertEqual(vlan_intf_table, {b'':b''})
         vlan_intf_table = self.configdb.hgetall(VLAN_INTF_TB + '|' + VLAN_NAME_PREF + '2')
-        self.assertEqual(vlan_intf_table, {b'vnet_name': VNET_NAME_PREF+'1'})
+        self.assertEqual(vlan_intf_table, {b'proxy_arp': b'enabled', b'vnet_name': VNET_NAME_PREF+'1'})
 
         # delete
         r = self.delete_config_vlan(2)


### PR DESCRIPTION
Add proxy_arp for Vnet interface 
Swss PR - https://github.com/Azure/sonic-swss/pull/1285

Unit test result:

```
test_vlan_all_args_all_verbs (__main__.ra_client_positive_tests) ... ok
test_vlan_with_vnetid_all_verbs (__main__.ra_client_positive_tests) ... ok
```