### PR TITLE
Program VNET routes to APP DB instead of Config DB

### DIFF
--- a/go-server-server/go/default.go
+++ b/go-server-server/go/default.go
@@ -1032,11 +1032,13 @@ func ConfigVrouterVrfIdRoutesPatch(w http.ResponseWriter, r *http.Request) {
              log.Printf("Skipping route %v as it is a baremetal /32 route", r)
 		       continue
 		  }
+
+        rt_tb_name := ROUTE_TUN_TB
         if *RunApiAsLocalTestDocker {
-             rt_tb_key = generateDBTableKey(db.separator, "_"+ROUTE_TUN_TB, vnet_id_str, r.IPPrefix)
-        } else {
-             rt_tb_key = generateDBTableKey(db.separator, ROUTE_TUN_TB, vnet_id_str, r.IPPrefix)
+            rt_tb_name = "_"+ROUTE_TUN_TB
         }
+        rt_tb_key = generateDBTableKey(db.separator, rt_tb_name, vnet_id_str, r.IPPrefix)
+
 		  cur_route, err := GetKVs(db.db_num, rt_tb_key)/* generateDBTableKey(db.separator, ROUTE_TUN_TB, vnet_id_str, r.IPPrefix))*/
 		  if err != nil {
              r.Error_code = http.StatusInternalServerError

--- a/go-server-server/go/default.go
+++ b/go-server-server/go/default.go
@@ -123,9 +123,9 @@ func ConfigInterfaceVlanDelete(w http.ResponseWriter, r *http.Request) {
             ip_pref := k[(len(generateDBTableKey(db.separator,VLAN_INTF_TB, vlan_name)) + 1):]
              _, vlan_netw, _ := net.ParseCIDR(ip_pref)
             vnet_id_str := vlan_if_kv["vnet_name"]
-            local_subnet_route_pt := swsscommon.NewTable(db.swss_db, CFG_LOCAL_ROUTE_TB)
+            local_subnet_route_pt := swsscommon.NewProducerStateTable(app_db_ops.swss_db, LOCAL_ROUTE_TB)
             defer local_subnet_route_pt.Delete()
-            local_subnet_route_pt.Del(generateDBTableKey(db.separator, vnet_id_str, vlan_netw.String()), "DEL", "")
+            local_subnet_route_pt.Del(generateDBTableKey(app_db_ops.separator, vnet_id_str, vlan_netw.String()), "DEL", "")
         }
     }
 
@@ -225,12 +225,12 @@ func ConfigInterfaceVlanPost(w http.ResponseWriter, r *http.Request) {
         }
         vlan_if_pt.Set(generateDBTableKey(db.separator, vlan_name, attr.IPPrefix), map[string]string{"":""}, "SET", "")
         if attr.Vnet_id != "" {
-             local_subnet_route_pt := swsscommon.NewTable(db.swss_db, CFG_LOCAL_ROUTE_TB)
+             local_subnet_route_pt := swsscommon.NewProducerStateTable(app_db_ops.swss_db, LOCAL_ROUTE_TB)
              defer local_subnet_route_pt.Delete()
              // No error check for IPPrefix since it is already checked in unmarshal
              _, vlan_netw, _ := net.ParseCIDR(attr.IPPrefix)
              local_subnet_route_pt.Set(
-                 generateDBTableKey(db.separator, vnet_id_str, vlan_netw.String()),
+                 generateDBTableKey(app_db_ops.separator, vnet_id_str, vlan_netw.String()),
                  map[string]string{"ifname": vlan_name},
              "SET", "")
         }
@@ -897,7 +897,7 @@ func ConfigVrouterVrfIdPost(w http.ResponseWriter, r *http.Request) {
 
 func ConfigVrouterVrfIdRoutesDelete(w http.ResponseWriter, r *http.Request) {
     w.Header().Set("Content-Type", "application/json; charset=UTF-8")
-    db := &conf_db_ops
+    db := &app_db_ops
     vars := mux.Vars(r)
 
     vnet_id_str, _, err := get_and_validate_vnet_id(w, vars["vnet_name"])
@@ -925,7 +925,7 @@ func ConfigVrouterVrfIdRoutesDelete(w http.ResponseWriter, r *http.Request) {
     }
 
     var failed []RouteModel
-    pt := swsscommon.NewTable(db.swss_db, CFG_ROUTE_TUN_TB)
+    pt := swsscommon.NewProducerStateTable(db.swss_db, ROUTE_TUN_TB)
     defer pt.Delete()
 
     for _, r := range routes {
@@ -989,7 +989,7 @@ func ConfigVrouterVrfIdRoutesGet(w http.ResponseWriter, r *http.Request) {
 
 func ConfigVrouterVrfIdRoutesPatch(w http.ResponseWriter, r *http.Request) {
     w.Header().Set("Content-Type", "application/json; charset=UTF-8")
-    db := &conf_db_ops
+    db := &app_db_ops
     vars := mux.Vars(r)
     var rt_tb_key string
 
@@ -1015,7 +1015,7 @@ func ConfigVrouterVrfIdRoutesPatch(w http.ResponseWriter, r *http.Request) {
         return
     }
 
-    pt := swsscommon.NewTable(db.swss_db, CFG_ROUTE_TUN_TB)
+    pt := swsscommon.NewProducerStateTable(db.swss_db, ROUTE_TUN_TB)
     defer pt.Delete()
 
     var failed []RouteModel
@@ -1032,9 +1032,11 @@ func ConfigVrouterVrfIdRoutesPatch(w http.ResponseWriter, r *http.Request) {
              log.Printf("Skipping route %v as it is a baremetal /32 route", r)
 		       continue
 		  }
-        // TODO: Remove if else and correct getkvs in production code
-        rt_tb_key = generateDBTableKey(db.separator, CFG_ROUTE_TUN_TB, vnet_id_str, r.IPPrefix)
-       
+        if *RunApiAsLocalTestDocker {
+             rt_tb_key = generateDBTableKey(db.separator, "_"+ROUTE_TUN_TB, vnet_id_str, r.IPPrefix)
+        } else {
+             rt_tb_key = generateDBTableKey(db.separator, ROUTE_TUN_TB, vnet_id_str, r.IPPrefix)
+        }
 		  cur_route, err := GetKVs(db.db_num, rt_tb_key)/* generateDBTableKey(db.separator, ROUTE_TUN_TB, vnet_id_str, r.IPPrefix))*/
 		  if err != nil {
              r.Error_code = http.StatusInternalServerError

--- a/go-server-server/go/persistent.go
+++ b/go-server-server/go/persistent.go
@@ -219,10 +219,13 @@ func GetKVsMulti(DB int, pattern string) (kv map[string]map[string]string, err e
 }
 
 func SwssGetVrouterRoutes(vnet_id_str string, vnidMatch int, ipFilter string) (routes []RouteModel, err error) {
-    db := &conf_db_ops
+    db := &app_db_ops
     var pattern string
-    // TODO: Keep only else statement code in production
-    pattern = generateDBTableKey(db.separator, CFG_ROUTE_TUN_TB, vnet_id_str, ipFilter)
+    if *RunApiAsLocalTestDocker {
+        pattern = generateDBTableKey(db.separator, "_"+ROUTE_TUN_TB, vnet_id_str, ipFilter)
+    } else {
+        pattern = generateDBTableKey(db.separator, ROUTE_TUN_TB, vnet_id_str, ipFilter)
+    }
     routes = []RouteModel{}
 
     kv, err := GetKVsMulti(db.db_num,pattern)

--- a/go-server-server/go/persistent.go
+++ b/go-server-server/go/persistent.go
@@ -221,11 +221,12 @@ func GetKVsMulti(DB int, pattern string) (kv map[string]map[string]string, err e
 func SwssGetVrouterRoutes(vnet_id_str string, vnidMatch int, ipFilter string) (routes []RouteModel, err error) {
     db := &app_db_ops
     var pattern string
+
+    rt_tb_name := ROUTE_TUN_TB
     if *RunApiAsLocalTestDocker {
-        pattern = generateDBTableKey(db.separator, "_"+ROUTE_TUN_TB, vnet_id_str, ipFilter)
-    } else {
-        pattern = generateDBTableKey(db.separator, ROUTE_TUN_TB, vnet_id_str, ipFilter)
+        rt_tb_name = "_"+ROUTE_TUN_TB
     }
+    pattern = generateDBTableKey(db.separator, rt_tb_name, vnet_id_str, ipFilter)
     routes = []RouteModel{}
 
     kv, err := GetKVsMulti(db.db_num,pattern)

--- a/go-server-server/go/util.go
+++ b/go-server-server/go/util.go
@@ -203,10 +203,13 @@ func validateVlanID(vlan_id_str string) (vlanID int, err error) {
 }
 
 func generateVlanPrefixInVnet(vnet_id_str string) (vlanPrefixArr []string, err error) {
-    db := &conf_db_ops
-    // TODO: Remove if else and correct getkvs in production code
+    db := &app_db_ops
     var rt_tb_key string
-    rt_tb_key = generateDBTableKey(db.separator, CFG_LOCAL_ROUTE_TB, vnet_id_str, "*")
+    if *RunApiAsLocalTestDocker {
+        rt_tb_key = generateDBTableKey(db.separator, "_"+LOCAL_ROUTE_TB, vnet_id_str, "*")
+    } else {
+        rt_tb_key = generateDBTableKey(db.separator, LOCAL_ROUTE_TB, vnet_id_str, "*")
+    }
     kv, err := GetKVsMulti(db.db_num, rt_tb_key)
     if err != nil {
         return vlanPrefixArr, err
@@ -261,11 +264,14 @@ func vlan_dependencies_exist(vlan_name string) (vlan_dep bool, err error) {
 
 
 func vnet_dependencies_exist(vnet_id_str string) (vnet_dep bool, err error) {
-     db := &conf_db_ops
+     db := &app_db_ops
      var rt_tb_key string
      vnet_dep = false
-     // TODO: Remove if else and correct getkvs in production code
-     rt_tb_key = generateDBTableKey(db.separator, CFG_ROUTE_TUN_TB, vnet_id_str, "*")
+     if *RunApiAsLocalTestDocker {
+         rt_tb_key = generateDBTableKey(db.separator, "_"+ROUTE_TUN_TB, vnet_id_str, "*")
+     } else {
+         rt_tb_key = generateDBTableKey(db.separator, ROUTE_TUN_TB, vnet_id_str, "*")
+     }
      routes_kv, err := GetKVsMulti(db.db_num, rt_tb_key)/* generateDBTableKey(db.separator, ROUTE_TUN_TB, vnet_id_str, "*"))*/
      if err != nil {
         return

--- a/go-server-server/go/util.go
+++ b/go-server-server/go/util.go
@@ -205,11 +205,11 @@ func validateVlanID(vlan_id_str string) (vlanID int, err error) {
 func generateVlanPrefixInVnet(vnet_id_str string) (vlanPrefixArr []string, err error) {
     db := &app_db_ops
     var rt_tb_key string
+    rt_tb_name := LOCAL_ROUTE_TB
     if *RunApiAsLocalTestDocker {
-        rt_tb_key = generateDBTableKey(db.separator, "_"+LOCAL_ROUTE_TB, vnet_id_str, "*")
-    } else {
-        rt_tb_key = generateDBTableKey(db.separator, LOCAL_ROUTE_TB, vnet_id_str, "*")
+        rt_tb_name = "_"+LOCAL_ROUTE_TB
     }
+    rt_tb_key = generateDBTableKey(db.separator, rt_tb_name, vnet_id_str, "*")
     kv, err := GetKVsMulti(db.db_num, rt_tb_key)
     if err != nil {
         return vlanPrefixArr, err
@@ -267,11 +267,12 @@ func vnet_dependencies_exist(vnet_id_str string) (vnet_dep bool, err error) {
      db := &app_db_ops
      var rt_tb_key string
      vnet_dep = false
+
+     rt_tb_name := ROUTE_TUN_TB
      if *RunApiAsLocalTestDocker {
-         rt_tb_key = generateDBTableKey(db.separator, "_"+ROUTE_TUN_TB, vnet_id_str, "*")
-     } else {
-         rt_tb_key = generateDBTableKey(db.separator, ROUTE_TUN_TB, vnet_id_str, "*")
+         rt_tb_name = "_"+ROUTE_TUN_TB
      }
+     rt_tb_key = generateDBTableKey(db.separator, rt_tb_name, vnet_id_str, "*")
      routes_kv, err := GetKVsMulti(db.db_num, rt_tb_key)/* generateDBTableKey(db.separator, ROUTE_TUN_TB, vnet_id_str, "*"))*/
      if err != nil {
         return

--- a/test/apitest.py
+++ b/test/apitest.py
@@ -212,7 +212,7 @@ class rest_api_client(unittest.TestCase):
 
     def check_routes_exist_in_db(self, vnet_num_mapped, routes_arr):
        for route in routes_arr:
-           route_table = self.configdb.hgetall(CFG_ROUTE_TUN_TB + '|' + VNET_NAME_PREF +str(vnet_num_mapped)+'|'+route['ip_prefix'])
+           route_table = self.db.hgetall(ROUTE_TUN_TB + ':' + VNET_NAME_PREF +str(vnet_num_mapped)+':'+route['ip_prefix'])
            self.assertEqual(route_table, {
                             b'endpoint' : route['nexthop'],
                             b'mac_address' : route['mac_address'],
@@ -221,7 +221,7 @@ class rest_api_client(unittest.TestCase):
 
     def check_routes_dont_exist_in_db(self, vnet_num_mapped, routes_arr):
        for route in routes_arr:
-           route_table = self.configdb.hgetall(CFG_ROUTE_TUN_TB + '|' + VNET_NAME_PREF +str(vnet_num_mapped)+'|'+route['ip_prefix'])
+           route_table = self.db.hgetall(ROUTE_TUN_TB + ':' + VNET_NAME_PREF +str(vnet_num_mapped)+':'+route['ip_prefix'])
            self.assertEqual(route_table, {})
 
     # Test setup
@@ -774,7 +774,7 @@ class ra_client_positive_tests(rest_api_client):
                 }
         r = self.patch_config_vrouter_vrf_id_routes("vnet-guid-1", [route])
         self.assertEqual(r.status_code, 204)
-        route_table = self.configdb.hgetall(CFG_ROUTE_TUN_TB + '|' + VNET_NAME_PREF +str(1)+'|'+route['ip_prefix'])
+        route_table = self.db.hgetall(ROUTE_TUN_TB + ':' + VNET_NAME_PREF +str(1)+':'+route['ip_prefix'])
         self.assertEqual(route_table, {b'endpoint' : route['nexthop']})
         del route['cmd']
         r = self.get_config_vrouter_vrf_id_routes("vnet-guid-1")
@@ -787,7 +787,7 @@ class ra_client_positive_tests(rest_api_client):
         route['cmd'] = 'add'
         r = self.patch_config_vrouter_vrf_id_routes("vnet-guid-1", [route])
         self.assertEqual(r.status_code, 204)
-        route_table = self.configdb.hgetall(CFG_ROUTE_TUN_TB + '|' + VNET_NAME_PREF +str(1)+'|'+route['ip_prefix'])
+        route_table = self.db.hgetall(ROUTE_TUN_TB + ':' + VNET_NAME_PREF +str(1)+':'+route['ip_prefix'])
         self.assertEqual(route_table, {b'endpoint' : route['nexthop'],
                                        b'vni' : str(route['vnid'])
                                       })
@@ -803,7 +803,7 @@ class ra_client_positive_tests(rest_api_client):
         route['cmd'] = 'add'
         r = self.patch_config_vrouter_vrf_id_routes("vnet-guid-1", [route])
         self.assertEqual(r.status_code, 204)
-        route_table = self.configdb.hgetall(CFG_ROUTE_TUN_TB + '|' + VNET_NAME_PREF +str(1)+'|'+route['ip_prefix'])
+        route_table = self.db.hgetall(ROUTE_TUN_TB + ':' + VNET_NAME_PREF +str(1)+':'+route['ip_prefix'])
         self.assertEqual(route_table, {b'endpoint' : route['nexthop'],
                                        b'mac_address' : route['mac_address']
                                       })
@@ -964,11 +964,11 @@ class ra_client_positive_tests(rest_api_client):
         
     def test_local_subnet_route_addition(self):
         self.post_generic_vlan_and_deps()
-        local_route_table = self.configdb.hgetall(CFG_LOCAL_ROUTE_TB + '|' + VNET_NAME_PREF +str(1)+'|10.1.1.0/24')
+        local_route_table = self.db.hgetall(LOCAL_ROUTE_TB + ':' + VNET_NAME_PREF +str(1)+':10.1.1.0/24')
         self.assertEqual(local_route_table, {b'ifname' : VLAN_NAME_PREF + '2'})
         r = self.delete_config_vlan(2)
         self.assertEqual(r.status_code, 204)
-        local_route_table = self.configdb.hgetall(CFG_LOCAL_ROUTE_TB + '|' + VNET_NAME_PREF +str(1)+'|10.1.1.0/24')
+        local_route_table = self.db.hgetall(LOCAL_ROUTE_TB + ':' + VNET_NAME_PREF +str(1)+':10.1.1.0/24')
         self.assertEqual(local_route_table, {})
 
     # Operations


### PR DESCRIPTION
1. BB requires routes to be programmed to App DB. 
2. Few places have alignment issues, but in this PR, kept as it is in the current file. Need to have a file wise alignment fix as a future commit
3. `python apitest.py` -> All passed
