### PR TITLE
Accept subnet routes via tunnel, skip self loopback nexthop

### DIFF
--- a/go-server-server/go/util.go
+++ b/go-server-server/go/util.go
@@ -245,6 +245,22 @@ func isBMNextHop(ipprefix string, vlanPrefixArr []string) (bm_next_hop bool, err
 	 return
 }
 
+func isLocalTunnelNexthop(ipNextHop string) (local_next_hop bool) {
+    local_next_hop = false
+    lpbk_ips := localTunnelLpbkIps
+    if (ipNextHop == "" || len(lpbk_ips) == 0) {
+        return
+    }
+
+    for _, s := range lpbk_ips {
+        if s == ipNextHop {
+            local_next_hop = true
+            return local_next_hop
+        }
+    }
+    return
+}
+
 func vlan_dependencies_exist(vlan_name string) (vlan_dep bool, err error) {
     db := &conf_db_ops
     vlan_dep = false

--- a/test/apitest.py
+++ b/test/apitest.py
@@ -851,7 +851,7 @@ class ra_client_positive_tests(rest_api_client):
              for ci in cidr:
 		routes.append({'cmd':'add',
                             'ip_prefix':'10.1.'+str(i)+'.1/'+str(ci),
-                            'nexthop':'192.168.2.'+str(i),
+                            'nexthop':'34.53.'+str(i)+'.0',
                             'vnid': 1 + i%5,
                             'mac_address':'00:08:aa:bb:cd:'+hex(15+i)[2:]})
 
@@ -862,7 +862,7 @@ class ra_client_positive_tests(rest_api_client):
         routes_not_bm = []
         for route in routes:
              del route['cmd']
-             if route['ip_prefix'] == '10.1.1.1/32' or  route['ip_prefix'] == '10.1.5.1/32':
+             if route['nexthop'] == '34.53.1.0':
                   routes_bm.append(route)
              else:
                   routes_not_bm.append(route)


### PR DESCRIPTION
1. Accept CA routes pointing to tunnel, even if it is within the same subnet
2. Skip tunnel routes if the endpoint is same as self loopback ip
3. Update pytest case to handle new scenarios