### PR TITLE
Use RESTAPI_DB, cache reset_status

### DIFF
--- a/go-server-server/go/default.go
+++ b/go-server-server/go/default.go
@@ -63,6 +63,7 @@ func ConfigResetStatusPost(w http.ResponseWriter, r *http.Request) {
         WriteRequestError(w, http.StatusBadRequest, "Malformed arguments for API call", []string{"reset_status"}, "only true/false values accepted")
         return
     }
+    CacheSetResetStatusInfo(ConfigResetStatus)
     ConfigResetStatusGet(w, r)    
 }
 


### PR DESCRIPTION
1. As defined in database config, use RESTAPI_DB for cache
2. reset_status must be saved/restored in DB during warmboot scenarios else will incorrectly trigger reprogramming