### PR TITLE
Add support for max_routes config per VRF

### DIFF
--- a/go-server-server/go/default.go
+++ b/go-server-server/go/default.go
@@ -866,13 +866,52 @@ func ConfigVrouterVrfIdGet(w http.ResponseWriter, r *http.Request) {
         WriteRequestError(w, http.StatusInternalServerError, "Internal service error, Non numeric vnid found in db", []string{}, "")
         return
     }
-
     output := VnetReturnModel{
         VnetName: vars["vnet_name"],
         Attr: VnetModel{
             Vnid: vnid,
-            Ipv4MaxRoutes: 0,
         },
+    }
+    var ipv4MaxRoutesNum int
+    ipv4MaxRoutesNumStr, ok := kv["ipv4_max_routes_num"]
+    if (ok) {
+        ipv4MaxRoutesNum, err = strconv.Atoi(ipv4MaxRoutesNumStr)
+        if err != nil {
+            WriteRequestError(w, http.StatusInternalServerError, "Internal service error, Non numeric ipv4_max_routes_num found in db", []string{}, "")
+            return
+        }
+        var ipv4MaxRoutesThreshold int
+        ipv4MaxRoutesThresholdStr, ok := kv["ipv4_max_routes_threshold"]
+        if (ok) {
+            ipv4MaxRoutesThreshold, err = strconv.Atoi(ipv4MaxRoutesThresholdStr)
+            if err != nil {
+                WriteRequestError(w, http.StatusInternalServerError, "Internal service error, Non numeric ipv4_max_routes_threshold found in db", []string{}, "")
+                return
+            }
+        }
+        tmpIpv4MaxRoutes := MaxRoutesModel { ipv4MaxRoutesNum, ipv4MaxRoutesThreshold }
+        output.Attr.Ipv4MaxRoutes = &tmpIpv4MaxRoutes
+    }
+
+    var ipv6MaxRoutesNum int
+    ipv6MaxRoutesNumStr, ok := kv["ipv6_max_routes_num"]
+    if (ok) {
+        ipv6MaxRoutesNum, err = strconv.Atoi(ipv6MaxRoutesNumStr)
+        if err != nil {
+            WriteRequestError(w, http.StatusInternalServerError, "Internal service error, Non numeric ipv6_max_routes_num found in db", []string{}, "")
+            return
+        }
+        var ipv6MaxRoutesThreshold int
+        ipv6MaxRoutesThresholdStr, ok := kv["ipv6_max_routes_threshold"]
+        if (ok) {
+            ipv6MaxRoutesThreshold, err = strconv.Atoi(ipv6MaxRoutesThresholdStr)
+            if err != nil {
+                WriteRequestError(w, http.StatusInternalServerError, "Internal service error, Non numeric ipv6_max_routes_threshold found in db", []string{}, "")
+                return
+            }
+        }
+        tmpIpv6MaxRoutes := MaxRoutesModel { ipv6MaxRoutesNum, ipv6MaxRoutesThreshold }
+        output.Attr.Ipv6MaxRoutes = &tmpIpv6MaxRoutes
     }
 
     WriteRequestResponse(w, output, http.StatusOK)
@@ -935,8 +974,14 @@ func ConfigVrouterVrfIdPost(w http.ResponseWriter, r *http.Request) {
         "vni": strconv.Itoa(attr.Vnid),
         "guid": vars["vnet_name"],
     }
-    if (attr.Ipv4MaxRoutes != 0) {
-        x["ipv4_max_routes"] = strconv.Itoa(attr.Ipv4MaxRoutes)
+
+    if (attr.Ipv4MaxRoutes != nil) {
+        x["ipv4_max_routes_num"] = strconv.Itoa(attr.Ipv4MaxRoutes.Num)
+        x["ipv4_max_routes_threshold"] = strconv.Itoa(attr.Ipv4MaxRoutes.Threshold)
+    }
+    if (attr.Ipv6MaxRoutes != nil) {
+        x["ipv6_max_routes_num"] = strconv.Itoa(attr.Ipv6MaxRoutes.Num)
+        x["ipv6_max_routes_threshold"] = strconv.Itoa(attr.Ipv6MaxRoutes.Threshold)
     }
     pt.Set(vnet_id_str, x, "SET", "")
 

--- a/go-server-server/go/default.go
+++ b/go-server-server/go/default.go
@@ -871,6 +871,7 @@ func ConfigVrouterVrfIdGet(w http.ResponseWriter, r *http.Request) {
         VnetName: vars["vnet_name"],
         Attr: VnetModel{
             Vnid: vnid,
+            Ipv4MaxRoutes: 0,
         },
     }
 
@@ -933,6 +934,7 @@ func ConfigVrouterVrfIdPost(w http.ResponseWriter, r *http.Request) {
     pt.Set(vnet_id_str, map[string]string{
         "vxlan_tunnel": "default_vxlan_tunnel",
         "vni": strconv.Itoa(attr.Vnid),
+        "ipv4_max_routes": "",
         "guid": vars["vnet_name"],
     }, "SET", "")
 

--- a/go-server-server/go/default.go
+++ b/go-server-server/go/default.go
@@ -930,13 +930,15 @@ func ConfigVrouterVrfIdPost(w http.ResponseWriter, r *http.Request) {
 
     pt := swsscommon.NewTable(db.swss_db, VNET_TB)
     defer pt.Delete()
-
-    pt.Set(vnet_id_str, map[string]string{
+    x := map[string]string{
         "vxlan_tunnel": "default_vxlan_tunnel",
         "vni": strconv.Itoa(attr.Vnid),
-        "ipv4_max_routes": "",
         "guid": vars["vnet_name"],
-    }, "SET", "")
+    }
+    if (attr.Ipv4MaxRoutes != 0) {
+        x["ipv4_max_routes"] = strconv.Itoa(attr.Ipv4MaxRoutes)
+    }
+    pt.Set(vnet_id_str, x, "SET", "")
 
     w.WriteHeader(http.StatusNoContent)
 }

--- a/go-server-server/go/default.go
+++ b/go-server-server/go/default.go
@@ -866,6 +866,7 @@ func ConfigVrouterVrfIdGet(w http.ResponseWriter, r *http.Request) {
         WriteRequestError(w, http.StatusInternalServerError, "Internal service error, Non numeric vnid found in db", []string{}, "")
         return
     }
+
     output := VnetReturnModel{
         VnetName: vars["vnet_name"],
         Attr: VnetModel{

--- a/go-server-server/go/models.go
+++ b/go-server-server/go/models.go
@@ -118,6 +118,7 @@ type TunnelDecapReturnModel struct {
 
 type VnetModel struct {
     Vnid int `json:"vnid"`
+    Ipv4MaxRoutes int `json:"ipv4_max_routes,omitempty"`
 }
 
 type VnetReturnModel struct {
@@ -309,6 +310,7 @@ func (m *TunnelDecapModel) UnmarshalJSON(data []byte) (err error) {
 func (m *VnetModel) UnmarshalJSON(data []byte) (err error) {
     required := struct {
         Vnid *int `json:"vnid"`
+        Ipv4MaxRoutes *int `json:"ipv4_max_routes,omitempty"`
     }{}
 
     err = json.Unmarshal(data, &required)
@@ -328,6 +330,7 @@ func (m *VnetModel) UnmarshalJSON(data []byte) (err error) {
     }
 
     m.Vnid = *required.Vnid
+    m.Ipv4MaxRoutes = 0
 
     return
 }

--- a/go-server-server/go/models.go
+++ b/go-server-server/go/models.go
@@ -4,6 +4,7 @@ import (
     "encoding/json"
     "net"
     "strconv"
+    "fmt"
 )
 
 type HeartbeatReturnModel struct {
@@ -330,7 +331,9 @@ func (m *VnetModel) UnmarshalJSON(data []byte) (err error) {
     }
 
     m.Vnid = *required.Vnid
-    m.Ipv4MaxRoutes = 0
+    if required.Ipv4MaxRoutes != nil {
+        m.Ipv4MaxRoutes = *required.Ipv4MaxRoutes
+    }
 
     return
 }

--- a/sonic_api.yaml
+++ b/sonic_api.yaml
@@ -1346,7 +1346,6 @@ definitions:
     type: object
     required:
       - vnid
-      - max_routes
     properties:
       vnid:
         type: integer

--- a/sonic_api.yaml
+++ b/sonic_api.yaml
@@ -1337,11 +1337,16 @@ definitions:
     type: object
     required:
       - vnid
+      - max_routes
     properties:
       vnid:
         type: integer
         format: int32
         description: vnid
+      max_routes:
+        type: integer
+        format: int32
+        description: maximum routes per vrf
   VlanEntry:
     type: object
     properties:

--- a/sonic_api.yaml
+++ b/sonic_api.yaml
@@ -1333,6 +1333,15 @@ definitions:
       ip_addr:
         type: string
         description: tunnel local termination IP address
+  MaxRoutesEntry:
+    type: object
+    properties:
+      num:
+        description: maximum routes which can advertised
+        type: integer
+      threshold:
+        description: after what threshold should a warning be generated (1-100)
+        type: integer
   VnetEntry:
     type: object
     required:
@@ -1343,10 +1352,10 @@ definitions:
         type: integer
         format: int32
         description: vnid
-      max_routes:
-        type: integer
-        format: int32
-        description: maximum routes per vrf
+      ipv4_max_routes:
+        $ref: '#/definitions/MaxRoutesEntry'
+      ipv6_max_routes:
+        $ref: '#/definitions/MaxRoutesEntry'
   VlanEntry:
     type: object
     properties:

--- a/test/apitest.py
+++ b/test/apitest.py
@@ -449,7 +449,14 @@ class ra_client_positive_tests(rest_api_client):
         self.post_generic_vxlan_tunnel()
         r = self.post_config_vrouter_vrf_id("vnet-guid-1", {
             'vnid': 1001,
-            'ipv4_max_routes': 1000
+            'ipv4_max_routes': {
+                                    'num': 1000,
+                                    'threshold': 80,
+                                },
+            'ipv6_max_routes': {
+                                    'num': 2000,
+                                    'threshold': 80,
+                                },
         })
         self.assertEqual(r.status_code, 204)
 
@@ -457,9 +464,44 @@ class ra_client_positive_tests(rest_api_client):
         self.assertEqual(vrouter_table, {
 							b'vxlan_tunnel': b'default_vxlan_tunnel',
 							b'vni': b'1001',
-                            b'ipv4_max_routes': b'1000',
+                            b'ipv4_max_routes_num': b'1000',
+                            b'ipv4_max_routes_threshold': b'80',
+                            b'ipv6_max_routes_num': b'2000',
+                            b'ipv6_max_routes_threshold': b'80',
 							b'guid': b'vnet-guid-1'
 							})
+
+    def test_get_vrouter_with_max_routes(self):
+        self.post_generic_vxlan_tunnel()
+        r = self.post_config_vrouter_vrf_id("vnet-guid-1", {
+            'vnid': 1001,
+            'ipv4_max_routes': {
+                                    'num': 1000,
+                                    'threshold': 80,
+                                },
+            'ipv6_max_routes': {
+                                    'num': 2000,
+                                    'threshold': 80,
+                                },
+        })
+        self.assertEqual(r.status_code, 204)
+        r = self.get_config_vrouter_vrf_id("vnet-guid-1")
+        self.assertEqual(r.status_code, 200)
+        j = json.loads(r.text)
+        self.assertEqual(j, {
+            'vnet_id': "vnet-guid-1",
+            'attr': {
+                'vnid': 1001,
+                'ipv4_max_routes': {
+                                    'num': 1000,
+                                    'threshold': 80,
+                                },
+                'ipv6_max_routes': {
+                                    'num': 2000,
+                                    'threshold': 80,
+                                },
+            }
+        })
 
 # Vlan
     def test_vlan_wo_ippref_vnetid_all_verbs(self):

--- a/test/apitest.py
+++ b/test/apitest.py
@@ -444,7 +444,22 @@ class ra_client_positive_tests(rest_api_client):
                      b'vni': b'100'+str(i+6),
                      b'guid': b'vnet-guid-'+str(i+6)
                      })
-             
+
+    def test_post_vrouter_with_max_routes(self):
+        self.post_generic_vxlan_tunnel()
+        r = self.post_config_vrouter_vrf_id("vnet-guid-1", {
+            'vnid': 1001,
+            'ipv4_max_routes': 1000
+        })
+        self.assertEqual(r.status_code, 204)
+
+        vrouter_table = self.configdb.hgetall(VNET_TB + '|' + VNET_NAME_PREF + '1')
+        self.assertEqual(vrouter_table, {
+							b'vxlan_tunnel': b'default_vxlan_tunnel',
+							b'vni': b'1001',
+                            b'ipv4_max_routes': b'1000',
+							b'guid': b'vnet-guid-1'
+							})
 
 # Vlan
     def test_vlan_wo_ippref_vnetid_all_verbs(self):


### PR DESCRIPTION
Adding optional fields in vrouter API to configure max routes per address family for a VRF