### PR TITLE
Making VNid optional in VRF

### DIFF
--- a/sonic_api.yaml
+++ b/sonic_api.yaml
@@ -1335,8 +1335,6 @@ definitions:
         description: tunnel local termination IP address
   VnetEntry:
     type: object
-    required:
-      - vnid
     properties:
       vnid:
         type: integer


### PR DESCRIPTION
More than one Vnets can be associated with one VRF, so make VNid optional while creating VRF/Vrouter