### PR TITLE
Uncomment error handling code for vxlan config

### DIFF
--- a/go-server-server/go/default.go
+++ b/go-server-server/go/default.go
@@ -773,8 +773,6 @@ func ConfigTunnelDecapTunnelTypePost(w http.ResponseWriter, r *http.Request) {
         return
     }
 
-    w.WriteHeader(http.StatusNoContent)
-/* Comment out all the code below this point in this fn once Day 0 config for VTEP is complete */
     var attr TunnelDecapModel
 
     err = ReadJSONBody(w, r, &attr)
@@ -785,13 +783,13 @@ func ConfigTunnelDecapTunnelTypePost(w http.ResponseWriter, r *http.Request) {
 
     kv, err := GetKVs(db.db_num, generateDBTableKey(db.separator, VXLAN_TUNNEL_TB, "default_vxlan_tunnel"))
     if err != nil {
-        /* WriteRequestError(w, http.StatusInternalServerError, "Internal service error", []string{}, "") */
+        WriteRequestError(w, http.StatusInternalServerError, "Internal service error", []string{}, "")
         return
     }
 
     if kv != nil {
-        /* WriteRequestErrorWithSubCode(w, http.StatusConflict, RESRC_EXISTS, 
-               "Object already exists: Default Vxlan VTEP", []string{}, "") */
+        WriteRequestErrorWithSubCode(w, http.StatusConflict, RESRC_EXISTS,
+               "Object already exists: Default Vxlan VTEP", []string{}, "")
         return
     }
 
@@ -803,6 +801,8 @@ func ConfigTunnelDecapTunnelTypePost(w http.ResponseWriter, r *http.Request) {
     }, "SET", "")
 
     CacheTunnelLpbkIps(attr.IPAddr, true)
+
+    w.WriteHeader(http.StatusNoContent)
 }
 
 func ConfigTunnelEncapVxlanVnidDelete(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
_API is returning both 204 and 400 in a misconfiguration_

```
restapi#supervisord: restapi [  info ] 2021/02/12 01:51:48 request: POST /v1/config/tunnel/decap/vxlan ConfigTunnelDecapTunnelTypePost
restapi#supervisord: restapi [  info ] 2021/02/12 01:51:48 request: return 204
restapi#supervisord: restapi [ debug ] 2021/02/12 01:51:48 request: body: {"ip_addr":" 10.1.0.32"}
restapi#supervisord: restapi [  info ] 2021/02/12 01:51:48 request: return 400
restapi#supervisord: restapi [  info ] 2021/02/12 01:51:48 http: superfluous response.WriteHeader call from go-server-server/go.LoggingResponseWriter.WriteHeader (logger.go:24)
restapi#supervisord: restapi [ error ] 2021/02/12 01:51:48 Request ends with error message {"error":{"code":400,"message":"Malformed arguments for API call","fields":["ip_addr"],"details":"Invalid IPv4 address"}}
```

