### PR TITLE
Default Vrf static route support

### DIFF
--- a/go-server-server/go/default.go
+++ b/go-server-server/go/default.go
@@ -1162,6 +1162,133 @@ func ConfigVrouterVrfIdRoutesPatch(w http.ResponseWriter, r *http.Request) {
     }
 }
 
+func ConfigVrfVrfIdRoutesPatch(w http.ResponseWriter, r *http.Request) {
+    w.Header().Set("Content-Type", "application/json; charset=UTF-8")
+    db := &conf_db_ops
+    vars := mux.Vars(r)
+    var rt_tb_key string
+    vrf_id_str := vars["vrf_id"]
+
+    if vrf_id_str != "default" {
+        // Only default is supported
+        WriteRequestError(w, http.StatusInternalServerError, "Internal service error", []string{}, "")
+        return
+    }
+
+    var attr []RouteModel
+
+    err := ReadJSONBody(w, r, &attr)
+    if err != nil {
+        // The error is already handled in this case
+        return
+    }
+
+    pt := swsscommon.NewTable(db.swss_db, STATIC_ROUTE_TB)
+    defer pt.Delete()
+
+    var rt_tb_name string
+    var failed []RouteModel
+
+    for _, r := range attr {
+
+        rt_tb_name = STATIC_ROUTE_TB
+        rt_tb_key = generateDBTableKey(db.separator, rt_tb_name, vrf_id_str, r.IPPrefix)
+
+        cur_route, err := GetKVs(db.db_num, rt_tb_key)
+        if err != nil {
+            r.Error_code = http.StatusInternalServerError
+            r.Error_msg = "Internal service error"
+            failed = append(failed, r)
+        }
+
+        if r.Cmd == "delete" {
+            if cur_route == nil {
+                r.Error_code = http.StatusNotFound
+                r.Error_msg = "Not found"
+                failed = append(failed, r)
+            } else {
+                pt.Del(generateDBTableKey(db.separator, vrf_id_str, r.IPPrefix), "DEL", "")
+            }
+        } else {
+            route_map := make(map[string]string)
+            if r.IfName == "" {
+                route_map["nexthop"] = r.NextHop
+            } else {
+                route_map["ifname"] = r.IfName
+                if r.NextHop != "" {
+                    route_map["nexthop"] = r.NextHop
+                }
+            }
+            if r.IfName == "null" {
+                route_map["blackhole"] = "true"
+            } else {
+                route_map["blackhole"] = "false"
+            }
+
+            pt.Set(generateDBTableKey(db.separator,vrf_id_str, r.IPPrefix), route_map, "SET", "")
+		}
+	}
+
+    if len(failed) > 0 {
+        output := RouteReturnModel {
+            Failed:  failed,
+        }
+        WriteRequestResponse(w, output, http.StatusMultiStatus)
+    } else {
+        w.WriteHeader(http.StatusNoContent)
+    }
+}
+
+func ConfigVrfVrfIdRoutesGet(w http.ResponseWriter, r *http.Request) {
+    w.Header().Set("Content-Type", "application/json; charset=UTF-8")
+    vars := mux.Vars(r)
+    vrf_id_str := vars["vrf_id"]
+
+    ipprefix := "*"
+    if len(r.URL.Query()["ip_prefix"]) == 1 {
+        ipprefix = r.URL.Query()["ip_prefix"][0]
+        _, _, err := ParseIPPrefix(ipprefix)
+        if err != nil {
+            WriteRequestError(w, http.StatusBadRequest, "Malformed arguments for API call", []string{"ip_prefix"}, "Invalid ip_prefix")
+            return
+        }
+    } else if len(r.URL.Query()["ip_prefix"]) > 1 {
+        WriteRequestError(w, http.StatusBadRequest, "Malformed arguments for API call", []string{"ip_prefix"}, "May only specify one ip_prefix")
+        return
+    }
+
+    db := &conf_db_ops
+    var pattern string
+
+    rt_tb_name := STATIC_ROUTE_TB
+
+    pattern = generateDBTableKey(db.separator, rt_tb_name, vrf_id_str, ipprefix)
+    routes := []RouteModel{}
+
+    kv, err := GetKVsMulti(db.db_num, pattern)
+    if err != nil {
+        WriteRequestError(w, http.StatusInternalServerError, "Internal service error", []string{}, "")
+        return
+    }
+
+    for k, kvp := range kv {
+        ipprefix := strings.Split(k, db.separator)[2]
+
+        routeModel := RouteModel{
+            IPPrefix:    ipprefix,
+            NextHop:     kvp["nexthop"],
+        }
+
+        if ifname, ok := kvp["ifname"]; ok {
+            routeModel.IfName = ifname
+        }
+
+        routes = append(routes, routeModel)
+    }
+
+    WriteRequestResponse(w, routes, http.StatusOK)
+}
+
 func StateInterfaceGet(w http.ResponseWriter, r *http.Request) {
     w.Header().Set("Content-Type", "application/json; charset=UTF-8")
 

--- a/go-server-server/go/default.go
+++ b/go-server-server/go/default.go
@@ -1226,8 +1226,8 @@ func ConfigVrfVrfIdRoutesPatch(w http.ResponseWriter, r *http.Request) {
             }
 
             pt.Set(generateDBTableKey(db.separator,vrf_id_str, r.IPPrefix), route_map, "SET", "")
-		}
-	}
+        }
+    }
 
     if len(failed) > 0 {
         output := RouteReturnModel {

--- a/go-server-server/go/default.go
+++ b/go-server-server/go/default.go
@@ -1210,6 +1210,16 @@ func ConfigVrfVrfIdRoutesPatch(w http.ResponseWriter, r *http.Request) {
                 pt.Del(generateDBTableKey(db.separator, vrf_id_str, r.IPPrefix), "DEL", "")
             }
         } else {
+            if cur_route != nil {
+                if cur_route["nexthop"] != r.NextHop ||
+                   cur_route["ifname"] != r.IfName {
+                    /* Delete and re-add the route as it is not identical */
+                    pt.Del(generateDBTableKey(db.separator,vrf_id_str, r.IPPrefix), "DEL", "")
+                } else {
+                    /* Identical route */
+                    continue
+                }
+            }
             route_map := make(map[string]string)
             if r.IfName == "" {
                 route_map["nexthop"] = r.NextHop
@@ -1221,8 +1231,6 @@ func ConfigVrfVrfIdRoutesPatch(w http.ResponseWriter, r *http.Request) {
             }
             if r.IfName == "null" {
                 route_map["blackhole"] = "true"
-            } else {
-                route_map["blackhole"] = "false"
             }
 
             pt.Set(generateDBTableKey(db.separator,vrf_id_str, r.IPPrefix), route_map, "SET", "")

--- a/go-server-server/go/models.go
+++ b/go-server-server/go/models.go
@@ -4,6 +4,7 @@ import (
     "encoding/json"
     "net"
     "strconv"
+    "strings"
 )
 
 type HeartbeatReturnModel struct {
@@ -211,7 +212,7 @@ func (m *RouteModel) UnmarshalJSON(data []byte) (err error) {
     }
 
     if required.NextHop != nil {
-        if !IsValidIPBoth(*required.NextHop) {
+        if !strings.Contains(*required.NextHop, ",") && !IsValidIPBoth(*required.NextHop) {
             err = &InvalidFormatError{Field: "nexthop", Message: "Invalid IP address"}
             return
         }

--- a/go-server-server/go/persistent.go
+++ b/go-server-server/go/persistent.go
@@ -53,6 +53,7 @@ const LOCAL_ROUTE_TB    string = "VNET_ROUTE_TABLE"
 const CFG_ROUTE_TUN_TB  string = "VNET_ROUTE_TUNNEL"
 const CFG_LOCAL_ROUTE_TB    string = "VNET_ROUTE"
 const CRM_TB            string = "CRM"
+const STATIC_ROUTE_TB   string = "STATIC_ROUTE"
 
 // DB Helper constants
 const VNET_NAME_PREF  string = "Vnet"

--- a/go-server-server/go/routers.go
+++ b/go-server-server/go/routers.go
@@ -272,6 +272,20 @@ var routes = Routes{
     },
 
     Route{
+        "ConfigVrfVrfIdRoutesGet",
+        "GET",
+        "/v1/config/vrf/{vrf_id}/routes",
+        ConfigVrfVrfIdRoutesGet,
+    },
+
+    Route{
+        "ConfigVrfVrfIdRoutesPatch",
+        "PATCH",
+        "/v1/config/vrf/{vrf_id}/routes",
+        ConfigVrfVrfIdRoutesPatch,
+    },
+
+    Route{
         "StateInterfacePortGet",
         "GET",
         "/v1/state/interface/{port}",


### PR DESCRIPTION
1. Add API support as per https://github.com/Azure/sonic-restapi/pull/82
2. Unit tests to check static route configs and other minor fixes for test functions

Example use:
Single nexthop IP
`curl --request PATCH -H "Content-Type:application/json" -d '[{"cmd":"add", "ip_prefix":"1.1.1.1/32", "nexthop":"10.1.0.57"}]' http://127.0.0.1:8081/v1/config/vrf/default/routes`

Single nexthop Interface name
`curl --request PATCH -H "Content-Type:application/json" -d '[{"cmd":"add", "ip_prefix":"2.2.2.2/32", "ifname":"PortChannel0001"}]' http://127.0.0.1:8081/v1/config/vrf/default/routes`

Multiple nexthop IPs [ECMP]
`curl --request PATCH -H "Content-Type:application/json" -d '[{"cmd":"add", "ip_prefix":"1.1.1.1/32", "nexthop":"10.1.0.57,10.1.0.59"}]' http://127.0.0.1:8081/v1/config/vrf/default/routes`

Blackhole route
`curl --request PATCH -H "Content-Type:application/json" -d '[{"cmd":"add", "ip_prefix":"100.0.1.20/32", "ifname":"null"}]' http://10.3.146.62:8090/v1/config/vrf/default/routes
`

Delete the route 1.1.1.1/32
`curl --request PATCH -H "Content-Type:application/json" -d '[{"cmd":"delete", "ip_prefix":"1.1.1.1/32", "nexthop":"10.1.0.57,10.1.0.61"}]' http://127.0.0.1:8081/v1/config/vrf/default/routes`