### PR TITLE
Upgrade Go version to 1.14

### DIFF
--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -45,7 +45,7 @@ RUN rm -fr /debs
 # && make \
 # && make install
 
-RUN export VERSION=1.11.5 \
+RUN export VERSION=1.14 \
  && cd /tmp \
  && wget https://storage.googleapis.com/golang/go$VERSION.linux-amd64.tar.gz \
  && tar -C /usr/local -xzf go$VERSION.linux-amd64.tar.gz \


### PR DESCRIPTION
The introduction of the GOFLAG `-modcacherw` in  https://github.com/Azure/sonic-restapi/pull/87 requires Go version `1.14` and hence caused a build failure:

```
cd /root/go/src/go-server-server && /usr/local/go/bin/go get -v && /usr/local/go/bin/go build -v
go: parsing $GOFLAGS: unknown flag -modcacherw
Makefile:18: recipe for target '/root/go/bin/go-server-server' failed
make[1]: Leaving directory '/src/rest'
make[1]: *** [/root/go/bin/go-server-server] Error 1
dh_auto_build: make -j1 returned exit code 2
debian/rules:22: recipe for target 'build' failed
make: *** [build] Error 2
dpkg-buildpackage: error: debian/rules build gave error exit status 2
```

This PR is meant to upgrade from the current `1.11.5` to `1.14`