### PR TITLE
Reject incorrect CIDR routes

### DIFF
--- a/go-server-server/go/default.go
+++ b/go-server-server/go/default.go
@@ -1075,6 +1075,20 @@ func ConfigVrouterVrfIdRoutesPatch(w http.ResponseWriter, r *http.Request) {
     defer local_pt.Delete()
 
     for _, r := range attr {
+
+        ip, network, err := net.ParseCIDR(r.IPPrefix)
+        if err != nil {
+            r.Error_msg = "Incorrect IP Prefix"
+            failed = append(failed, r)
+            continue
+        }
+
+        if ip.String() != strings.Split(network.String(), "/")[0] {
+            r.Error_msg = "Incorrect IP Prefix"
+            failed = append(failed, r)
+            continue
+        }
+
         if r.IfName == "" {
             pt = tunnel_pt
             rt_tb_name = ROUTE_TUN_TB
@@ -1190,6 +1204,19 @@ func ConfigVrfVrfIdRoutesPatch(w http.ResponseWriter, r *http.Request) {
     var failed []RouteModel
 
     for _, r := range attr {
+
+        ip, network, err := net.ParseCIDR(r.IPPrefix)
+        if err != nil {
+            r.Error_msg = "Incorrect IP Prefix"
+            failed = append(failed, r)
+            continue
+        }
+
+        if ip.String() != strings.Split(network.String(), "/")[0] {
+            r.Error_msg = "Incorrect IP Prefix"
+            failed = append(failed, r)
+            continue
+        }
 
         rt_tb_name = STATIC_ROUTE_TB
         rt_tb_key = generateDBTableKey(db.separator, rt_tb_name, vrf_id_str, r.IPPrefix)

--- a/go-server-server/go/default.go
+++ b/go-server-server/go/default.go
@@ -1076,6 +1076,11 @@ func ConfigVrouterVrfIdRoutesPatch(w http.ResponseWriter, r *http.Request) {
 
     for _, r := range attr {
 
+        /*
+        Reject incorrect CIDR address such as 10.20.30.4/24
+        Accept only correct CIDR addresses such as 10.20.30.0/24 or 10.20.30.4/32 
+        */
+
         ip, network, err := net.ParseCIDR(r.IPPrefix)
         if err != nil {
             r.Error_msg = "Incorrect IP Prefix"
@@ -1204,6 +1209,11 @@ func ConfigVrfVrfIdRoutesPatch(w http.ResponseWriter, r *http.Request) {
     var failed []RouteModel
 
     for _, r := range attr {
+
+        /*
+        Reject incorrect CIDR address such as 10.20.30.4/24
+        Accept only correct CIDR addresses such as 10.20.30.0/24 or 10.20.30.4/32 
+        */
 
         ip, network, err := net.ParseCIDR(r.IPPrefix)
         if err != nil {

--- a/test/apitest.py
+++ b/test/apitest.py
@@ -900,9 +900,18 @@ class ra_client_positive_tests(rest_api_client):
         self.assertEqual(r.status_code, 204)
         routes = []
         for i in range (1,7):
-             for ci in cidr:
-		routes.append({'cmd':'add',
-                            'ip_prefix':'10.1.'+str(i)+'.1/'+str(ci),
+		    routes.append({'cmd':'add',
+                            'ip_prefix':'10.5.'+str(i)+'.0/'+str(24),
+                            'nexthop':'34.53.'+str(i)+'.0',
+                            'vnid': 1 + i%5,
+                            'mac_address':'00:08:aa:bb:cd:'+hex(15+i)[2:]})
+		    routes.append({'cmd':'add',
+                            'ip_prefix':'10.5.'+str(i)+'.0/'+str(30),
+                            'nexthop':'34.53.'+str(i)+'.0',
+                            'vnid': 1 + i%5,
+                            'mac_address':'00:08:aa:bb:cd:'+hex(15+i)[2:]})
+		    routes.append({'cmd':'add',
+                            'ip_prefix':'10.5.'+str(i)+'.1/'+str(32),
                             'nexthop':'34.53.'+str(i)+'.0',
                             'vnid': 1 + i%5,
                             'mac_address':'00:08:aa:bb:cd:'+hex(15+i)[2:]})
@@ -942,9 +951,16 @@ class ra_client_positive_tests(rest_api_client):
         self.assertEqual(r.status_code, 204)
         routes = []
         for i in range (1,7):
-             for ci in cidr:
-		routes.append({'cmd':'add',
-                            'ip_prefix':'10.1.'+str(i)+'.1/'+str(ci),
+		    routes.append({'cmd':'add',
+                            'ip_prefix':'10.5.'+str(i)+'.0/'+str(24),
+                            'nexthop':'34.53.'+str(i)+'.0',
+                            'ifname': 'Vlan3005'})
+		    routes.append({'cmd':'add',
+                            'ip_prefix':'10.5.'+str(i)+'.0/'+str(30),
+                            'nexthop':'34.53.'+str(i)+'.0',
+                            'ifname': 'Vlan3005'})
+		    routes.append({'cmd':'add',
+                            'ip_prefix':'10.5.'+str(i)+'.1/'+str(32),
                             'nexthop':'34.53.'+str(i)+'.0',
                             'ifname': 'Vlan3005'})
 


### PR DESCRIPTION
Configuring incorrect CIDR addresses as routes is not permitted in SONiC and this PR will reject such incorrect routes from being configured using RestAPI.

In a batch config, if one or more routes are incorrect, only those routes will be rejected while the correct routes will be configured and an appropriate return-code will be sent.