### PR TITLE
Identify Vnet GUID for conflicting VNI

### DIFF
--- a/go-server-server/go/default.go
+++ b/go-server-server/go/default.go
@@ -917,7 +917,7 @@ func ConfigVrouterVrfIdPost(w http.ResponseWriter, r *http.Request) {
     guid := CacheGetVniId(uint32(attr.Vnid))
     if guid != "" {
         WriteRequestErrorWithSubCode(w, http.StatusConflict, RESRC_EXISTS,
-              "Object already exists: vni=" + strconv.Itoa(attr.Vnid) + " vnet_name=" + guid, []string{}, "")
+              "Object already exists {\"vni\":\"" + strconv.Itoa(attr.Vnid) + "\", \"vnet_name\":\"" + guid +"\"}", []string{}, "")
         return
     }
 

--- a/go-server-server/go/default.go
+++ b/go-server-server/go/default.go
@@ -917,7 +917,7 @@ func ConfigVrouterVrfIdPost(w http.ResponseWriter, r *http.Request) {
     guid := CacheGetVniId(uint32(attr.Vnid))
     if guid != "" {
         WriteRequestErrorWithSubCode(w, http.StatusConflict, RESRC_EXISTS,
-              "Object already exists: " + strconv.Itoa(attr.Vnid), []string{}, "")
+              "Object already exists: vni=" + strconv.Itoa(attr.Vnid) + " vnet_name=" + guid, []string{}, "")
         return
     }
 

--- a/test/test_restapi.py
+++ b/test/test_restapi.py
@@ -154,7 +154,7 @@ class TestRestApiPositive:
             'vnid': 1001
         })
         assert r.status_code == 409
-        assert r.json()['error']['message'] == "Object already exists: vni=1001 vnet_name=vnet-guid-1"
+        assert r.json()['error']['message'] == "Object already exists {\"vni\":\"1001\", \"vnet_name\":\"vnet-guid-1\"}"
 
     def test_post_vrouter_default(self, setup_restapi_client):
         _, _, configdb, restapi_client = setup_restapi_client

--- a/test/test_restapi.py
+++ b/test/test_restapi.py
@@ -135,6 +135,27 @@ class TestRestApiPositive:
 							b'guid': b'vnet-guid-1'
 							}
 
+    def test_post_vrouter_duplicate(self, setup_restapi_client):
+        _, _, configdb, restapi_client = setup_restapi_client
+        restapi_client.post_generic_vxlan_tunnel()
+        r = restapi_client.post_config_vrouter_vrf_id("vnet-guid-1", {
+            'vnid': 1001
+        })
+        assert r.status_code == 204
+
+        vrouter_table = configdb.hgetall(VNET_TB + '|' + VNET_NAME_PREF + '1')
+        assert vrouter_table == {
+							b'vxlan_tunnel': b'default_vxlan_tunnel',
+							b'vni': b'1001',
+							b'guid': b'vnet-guid-1'
+							}
+
+        r = restapi_client.post_config_vrouter_vrf_id("vnet-guid-2", {
+            'vnid': 1001
+        })
+        assert r.status_code == 409
+        assert r.json()['error']['message'] == "Object already exists: vni=1001 vnet_name=vnet-guid-1"
+
     def test_post_vrouter_default(self, setup_restapi_client):
         _, _, configdb, restapi_client = setup_restapi_client
         restapi_client.post_generic_vxlan_tunnel()


### PR DESCRIPTION
While creating a new VNET with the same VNI, the API caller might find it useful to know the exiting Vnet GUID for the conflicting VNI. Hence, we are modifying the VNET create API to return the Vnet GUID of the conflicting VNI

Existing response: "Object already exists: 1001"
New response: "Object already exists: {"vni": "1001",  "vnet_name": "vnet_guid_1"}