### PR TITLE
Fix urllib3 CVE-2021-33503 issue

### DIFF
--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -1,2 +1,2 @@
 redis==2.10.5
-requests==2.20.0
+requests==2.25.0


### PR DESCRIPTION
The pip package request==1.22.0 using urllib3 1.25.11, which has CVE-2021-33503 issue.
The urllib3 should be upgraded to 1.26.5.

```
# pip install requests==2.22.0      
Collecting requests==2.22.0
  Using cached https://files.pythonhosted.org/packages/51/bd/23c926cd341ea6b7dd0b2a00aba99ae0f828be89d72b2190f27c11d4b7fb/requests-2.22.0-py2.py3-none-any.whl
Requirement already satisfied: idna<2.9,>=2.5 in /usr/local/lib/python2.7/dist-packages (from requests==2.22.0) (2.7)
Requirement already satisfied: chardet<3.1.0,>=3.0.2 in /usr/local/lib/python2.7/dist-packages (from requests==2.22.0) (3.0.4)
Requirement already satisfied: certifi>=2017.4.17 in /usr/local/lib/python2.7/dist-packages (from requests==2.22.0) (2021.10.8)
Collecting urllib3!=1.25.0,!=1.25.1,<1.26,>=1.21.1 (from requests==2.22.0)
  Using cached https://files.pythonhosted.org/packages/56/aa/4ef5aa67a9a62505db124a5cb5262332d1d4153462eb8fd89c9fa41e5d92/urllib3-1.25.11-py2.py3-none-any.whl
Installing collected packages: urllib3, requests
Successfully installed requests-2.22.0 urllib3-1.25.11
```

```
# pip install requests==2.25.0       
Collecting requests==2.25.0
  Using cached https://files.pythonhosted.org/packages/39/fc/f91eac5a39a65f75a7adb58eac7fa78871ea9872283fb9c44e6545998134/requests-2.25.0-py2.py3-none-any.whl
Requirement already satisfied: idna<3,>=2.5 in /usr/local/lib/python2.7/dist-packages (from requests==2.25.0) (2.7)
Collecting urllib3<1.27,>=1.21.1 (from requests==2.25.0)
  Using cached https://files.pythonhosted.org/packages/4e/b8/f5a25b22e803f0578e668daa33ba3701bb37858ec80e08a150bd7d2cf1b1/urllib3-1.26.8-py2.py3-none-any.whl
Requirement already satisfied: certifi>=2017.4.17 in /usr/local/lib/python2.7/dist-packages (from requests==2.25.0) (2021.10.8)
Requirement already satisfied: chardet<4,>=3.0.2 in /usr/local/lib/python2.7/dist-packages (from requests==2.25.0) (3.0.4)
Installing collected packages: urllib3, requests
Successfully installed requests-2.25.0 urllib3-1.26.8
```
