### PR TITLE
Fix urllib3 CVE-2021-33503 issue (#104)

### DIFF
--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -1,2 +1,2 @@
 redis==2.10.5
-requests==2.20.0
+requests==2.25.0


### PR DESCRIPTION
The pip package request==1.22.0 using urllib3 1.25.11, which has CVE-2021-33503 issue.
The urllib3 should be upgraded to 1.26.5.