### PR TITLE
API for getting all members from all VLANs

### DIFF
--- a/go-server-server/go/default.go
+++ b/go-server-server/go/default.go
@@ -418,39 +418,6 @@ func ConfigInterfaceVlansMembersAllGet(w http.ResponseWriter, r *http.Request) {
     }
 
     for _,v := range vlan_map_kv{
-        /*
-        vlan_name := VLAN_NAME_PREF + v["vlanid"]
-        vlan_pref_kv, _ := GetKVsMulti(db.db_num, generateDBTableKey(db.separator, VLAN_INTF_TB, vlan_name, "*"))
-        vlan_if_kv, _ := GetKVs(db.db_num, generateDBTableKey(db.separator, VLAN_INTF_TB, vlan_name))
-
-        var vnet_guid string
-        if vlan_if_kv != nil {
-            vnet_id := vlan_if_kv["vnet_name"]
-            vmap, _ := GetKVs(db.db_num, generateDBTableKey(db.separator, VNET_TB, vnet_id))
-            vnet_guid = vmap["guid"]
-        }
-
-        var vlan_ip string
-        if len(vlan_pref_kv) > 0 {
-            for k,_ := range vlan_pref_kv {
-                 ip_pref := k[(len(generateDBTableKey(db.separator,VLAN_INTF_TB, vlan_name)) + 1):]
-                 ip, _, _ := net.ParseCIDR(ip_pref)
-                 if IsValidIP(ip.String()) != true {
-                     continue
-                 }
-                 vlan_ip = ip_pref
-            }
-        }
-
-        vlanInt,_ := strconv.Atoi(v["vlanid"])
-        output := VlansModel{
-                      VlanID: vlanInt,
-                      IPPrefix: vlan_ip,
-                      Vnet_id: vnet_guid,
-                  }
-        Vlans = append(Vlans,output)
-        */
-        //vlan_id := v["vlanid"]
         vlanInt,_ := strconv.Atoi(v["vlanid"])
         vlan_name := VLAN_NAME_PREF + v["vlanid"]
         // Getting all the key value pairs for VLAN_MEMBER|vlan_name*
@@ -466,6 +433,8 @@ func ConfigInterfaceVlansMembersAllGet(w http.ResponseWriter, r *http.Request) {
             WriteRequestResponse(w, MembersReturn, http.StatusOK)
         return
         }
+
+        Members = nil
         for k,v := range vlan_members_kv{
             output := VlanMembersModel{
                 If_name: k[len(generateDBTableKey(db.separator,VLAN_MEMB_TB,vlan_name))+1:],

--- a/go-server-server/go/default.go
+++ b/go-server-server/go/default.go
@@ -402,9 +402,6 @@ func ConfigInterfaceVlansMembersAllGet(w http.ResponseWriter, r *http.Request) {
     var MembersReturn VlanMembersReturnModel
     var MembersAllReturn VlanMembersAllReturnModel
 
-    //var Vlans []VlansModel
-    //var VlansReturn VlansReturnModel
-
     //Getting a map for all the vlans in DB
     vlan_map_kv, err := GetKVsMulti(db.db_num, generateDBTableKey(db.separator, VLAN_TB,  "*"))
     if err != nil {
@@ -417,6 +414,7 @@ func ConfigInterfaceVlansMembersAllGet(w http.ResponseWriter, r *http.Request) {
         return
     }
 
+    MembersAllReturn.Attr = make([]VlanMembersReturnModel, 0)
     for _,v := range vlan_map_kv{
         vlanInt,_ := strconv.Atoi(v["vlanid"])
         vlan_name := VLAN_NAME_PREF + v["vlanid"]
@@ -427,11 +425,7 @@ func ConfigInterfaceVlansMembersAllGet(w http.ResponseWriter, r *http.Request) {
         return
         }
         if len(vlan_members_kv) == 0 {
-        log.Printf("No members found for %v ", vlan_name)
-            MembersReturn.VlanID = vlanInt
-            MembersReturn.Attr = Members
-            WriteRequestResponse(w, MembersReturn, http.StatusOK)
-        return
+            continue
         }
 
         Members = nil

--- a/go-server-server/go/models.go
+++ b/go-server-server/go/models.go
@@ -81,8 +81,12 @@ type VlanMembersModel struct {
 }
 
 type VlanMembersReturnModel struct {
-    VlanID    int              `json:"vlan_id"`
+    VlanID    int                 `json:"vlan_id"`
     Attr      []VlanMembersModel  `json:"attr"`
+}
+
+type VlanMembersAllReturnModel struct {
+    Attr      []VlanMembersReturnModel  `json:"attr"`
 }
 
 type VlanNeighborReturnModel struct {

--- a/go-server-server/go/routers.go
+++ b/go-server-server/go/routers.go
@@ -132,6 +132,13 @@ var routes = Routes{
     },
 
     Route{
+        "ConfigInterfaceVlansMembersAllGet",
+        "GET",
+        "/v1/config/interface/vlans/members/all",
+        ConfigInterfaceVlansMembersAllGet,
+    },
+
+    Route{
         "ConfigInterfaceVlanMemberDelete",
         "DELETE",
         "/v1/config/interface/vlan/{vlan_id}/member/{if_name}",

--- a/sonic_api.yaml
+++ b/sonic_api.yaml
@@ -598,6 +598,45 @@ paths:
 #----------------------------------------------
 # VLAN interface member 
 #----------------------------------------------
+  '/config/interface/vlans/members/all':
+    get:
+      operationId: ConfigInterfaceVlansMembersAllGet
+      summary: Get information about all existing vlan members configured in the system
+      description: Returns attributes for vlans. If no vlans exist, it returns a '404' error.
+      responses:
+        '200':
+          description: OK
+          schema:
+            type: object
+            properties:
+              attr:
+                type: array
+                items:
+                  $ref: '#/definitions/VlanMembersAllEntry'
+                  vlan_id:
+                    type: string 
+                  members:
+                    type: array
+        '400':
+          description: Malformed arguments for API call
+          schema:
+            $ref: '#/definitions/Error'
+        '401':
+          description: Invalid authentication credentials
+          schema:
+            $ref: '#/definitions/Error'
+        '404':
+          description: Vnet_id is not found
+          schema:
+            $ref: '#/definitions/Error'
+        '500':
+          description: Internal service error
+          schema:
+            $ref: '#/definitions/Error'
+        '503':
+          description: Maintanence mode
+          schema:
+            $ref: '#/definitions/Error'
   '/config/interface/vlan/{vlan_id}/member/{if_name}':
     post:
       operationId: ConfigInterfaceVlanMemberPost

--- a/test/restapi_client.py
+++ b/test/restapi_client.py
@@ -139,6 +139,9 @@ class RESTAPI_client:
     def get_config_interface_vlan_members(self, vlan_id):
         return self.get('v1/config/interface/vlan/{vlan_id}/members'.format(vlan_id=vlan_id))
 
+    def get_config_members_all(self):
+        return self.get('v1/config/interface/vlans/members/all')
+
     # Vlan Neighbor
     def post_config_vlan_neighbor(self, vlan_id, ip_addr):
         return self.post('v1/config/interface/vlan/{vlan_id}/neighbor/{ip_addr}'.format(vlan_id=vlan_id, ip_addr=ip_addr)) 

--- a/test/test_restapi.py
+++ b/test/test_restapi.py
@@ -470,6 +470,11 @@ class TestRestApiPositive:
         restapi_client.post_config_vlan(3000, {'vnet_id' : 'vnet-guid-1', 'ip_prefix':'10.0.1.1/24'})
         restapi_client.post_config_vlan(3001, {'vnet_id' : 'vnet-guid-1'})
 
+        r = restapi_client.get_config_members_all()
+        assert r.status_code == 200
+        j = json.loads(r.text)
+        assert len(j["attr"]) == 0
+
         members = ["Ethernet2", "Ethernet3", "Ethernet4"]
         for member in members:
            r = restapi_client.post_config_vlan_member(3000, member, {'tagging_mode' : 'untagged'})

--- a/test/test_restapi.py
+++ b/test/test_restapi.py
@@ -482,18 +482,27 @@ class TestRestApiPositive:
 
         # get all vlans
         r = restapi_client.get_config_members_all()
+        assert r.status_code == 200
         j = json.loads(r.text)
-        #assert j == {}
-        '''
-        k = {"attr":[{"vlan_id":3000,"ip_prefix":"10.0.1.1/24","vnet_id":"vnet-guid-1"},{"vlan_id":3001,"vnet_id":"vnet-guid-1"}]}
-        for key,value in j.iteritems():
-            if type(value)!=list:
-                assert k[key] == j[key]
-                return
-            for item in k[key]:
-                if item not in value:
-                    assert False
-        '''
+        members_of_vlan3000 = [
+                {'if_name': 'Ethernet2', 'tagging_mode': 'untagged'},
+                {'if_name': 'Ethernet3', 'tagging_mode': 'untagged'},
+                {'if_name': 'Ethernet4', 'tagging_mode': 'untagged'}
+            ]
+        members_of_vlan3001 = [
+                {'if_name': 'Ethernet5', 'tagging_mode': 'untagged'},
+                {'if_name': 'Ethernet6', 'tagging_mode': 'untagged'},
+                {'if_name': 'Ethernet7', 'tagging_mode': 'untagged'}
+            ]
+
+        for item in j['attr']:
+            print(item)
+            if item['vlan_id'] == 3000:
+                for member in item['attr']:
+                    assert member in members_of_vlan3000
+            if item['vlan_id'] == 3001:
+                for member in item['attr']:
+                    assert member in members_of_vlan3001        
 
     # Vlan Member
     def test_vlan_member_tagged_untagged_interop(self, setup_restapi_client):

--- a/test/test_restapi.py
+++ b/test/test_restapi.py
@@ -457,6 +457,44 @@ class TestRestApiPositive:
                 if item not in value:
                     assert False
 
+    # Vlan Get
+    def test_get_all_members(self, setup_restapi_client):
+        _, _, _, restapi_client = setup_restapi_client
+        # create vxlan tunnel
+        restapi_client.post_config_tunnel_decap_tunnel_type('vxlan', {
+        'ip_addr': '6.6.6.6'
+        })
+        # create vnet_id/vrf
+        restapi_client.post_config_vrouter_vrf_id('vnet-guid-1', {'vnid': 1001})
+        #create vlan interfaces
+        restapi_client.post_config_vlan(3000, {'vnet_id' : 'vnet-guid-1', 'ip_prefix':'10.0.1.1/24'})
+        restapi_client.post_config_vlan(3001, {'vnet_id' : 'vnet-guid-1'})
+
+        members = ["Ethernet2", "Ethernet3", "Ethernet4"]
+        for member in members:
+           r = restapi_client.post_config_vlan_member(3000, member, {'tagging_mode' : 'untagged'})
+           assert r.status_code == 204
+
+        members = ["Ethernet5", "Ethernet6", "Ethernet7"]
+        for member in members:
+           r = restapi_client.post_config_vlan_member(3001, member, {'tagging_mode' : 'untagged'})
+           assert r.status_code == 204
+
+        # get all vlans
+        r = restapi_client.get_config_members_all()
+        j = json.loads(r.text)
+        #assert j == {}
+        '''
+        k = {"attr":[{"vlan_id":3000,"ip_prefix":"10.0.1.1/24","vnet_id":"vnet-guid-1"},{"vlan_id":3001,"vnet_id":"vnet-guid-1"}]}
+        for key,value in j.iteritems():
+            if type(value)!=list:
+                assert k[key] == j[key]
+                return
+            for item in k[key]:
+                if item not in value:
+                    assert False
+        '''
+
     # Vlan Member
     def test_vlan_member_tagged_untagged_interop(self, setup_restapi_client):
         _, _, _, restapi_client = setup_restapi_client


### PR DESCRIPTION
API: `/v1/config/interface/vlans/members/all`
Response: `attr: [
                              {'vlan_id': 3000, 'attr': [{'if_name': 'Ethernet5', 'tagging_mode': 'untagged'},
                                                                  {'if_name': 'Ethernet6', 'tagging_mode': 'untagged'}]},
                              {'vlan_id': 3001, 'attr': [{'if_name': 'Ethernet7', 'tagging_mode': 'untagged'}]}
                           ]`