### PR TITLE
Fix Ctype_char larger than address space issue in 32-bit armhf

### DIFF
--- a/swsscommon/producerstatetable.go
+++ b/swsscommon/producerstatetable.go
@@ -52,7 +52,7 @@ func (pt ProducerStateTable) Set(key string, values map[string]string, op string
     tuplePtr := (*C.field_value_tuple_t)(C.malloc(C.size_t(C.sizeof_field_value_tuple_t * count)))
     defer C.free(unsafe.Pointer(tuplePtr))
     // Get a Go slice to the C array - this doesn't allocate anything
-    tuples := (*[1 << 30]C.field_value_tuple_t)(unsafe.Pointer(tuplePtr))[:count:count]
+    tuples := (*[(1 << 28) - 1]C.field_value_tuple_t)(unsafe.Pointer(tuplePtr))[:count:count]
 
     idx := 0
     for k, v := range values {

--- a/swsscommon/table.go
+++ b/swsscommon/table.go
@@ -52,7 +52,7 @@ func (pt Table) Set(key string, values map[string]string, op string, prefix stri
     tuplePtr := (*C.field_value_tuple_t)(C.malloc(C.size_t(C.sizeof_field_value_tuple_t * count)))
     defer C.free(unsafe.Pointer(tuplePtr))
     // Get a Go slice to the C array - this doesn't allocate anything
-    tuples := (*[1 << 30]C.field_value_tuple_t)(unsafe.Pointer(tuplePtr))[:count:count]
+    tuples := (*[(1 << 28) - 1]C.field_value_tuple_t)(unsafe.Pointer(tuplePtr))[:count:count]
 
     idx := 0
     for k, v := range values {


### PR DESCRIPTION
Fix Ctype_char larger than address space issue in 32-bit ARM (armhf)

```
../swsscommon/producerstatetable.go:55:17: type [1073741824]_Ctype_struct_field_value_tuple larger than address space
../swsscommon/producerstatetable.go:55:17: type [1073741824]_Ctype_struct_field_value_tuple too large
../swsscommon/table.go:55:17: type [1073741824]_Ctype_struct_field_value_tuple larger than address space
../swsscommon/table.go:55:17: type [1073741824]_Ctype_struct_field_value_tuple too large
```
Tested on armv8l, similar [fix](https://github.com/tecbot/gorocksdb/pull/173/files) to change to (1<<29) -1 is not enough, need to change to (1<<28)-1.

Why adding armhf support:
https://github.com/Azure/sonic-buildimage/issues/9896
