### PR TITLE
libyang3: update from libyang1

### DIFF
--- a/Dockerfile.common.prod
+++ b/Dockerfile.common.prod
@@ -17,7 +17,7 @@ RUN dpkg -i /debs/libhiredis0.13_0.13.3-2_amd64.deb \
  && dpkg -i /debs/libnl-3-200_3.2.27-1_amd64.deb \
  && dpkg -i /debs/libnl-genl-3-200_3.2.27-1_amd64.deb \
  && dpkg -i /debs/libnl-route-3-200_3.2.27-1_amd64.deb \
- && dpkg -i /debs/libyang_1.0.73_amd64.deb \
+ && dpkg -i /debs/libyang_3.7.8-2_amd64.deb \
  && dpkg -i /debs/libswsscommon_1.0.0_amd64.deb \
  && dpkg -i /debs/libswsscommon-dev_1.0.0_amd64.deb \
  && dpkg -i /debs/sonic-rest-api_1.0.1_amd64.deb \

--- a/copy.sh
+++ b/copy.sh
@@ -8,6 +8,6 @@ wget -O debs/libnl-genl-3-200_3.5.0-1_amd64.deb  'https://sonic-build.azurewebsi
 wget -O debs/libnl-route-3-200_3.5.0-1_amd64.deb  'https://sonic-build.azurewebsites.net/api/sonic/artifacts?branchName=master&platform=vs&target=target/debs/buster/libnl-route-3-200_3.5.0-1_amd64.deb'
 wget -O debs/libnl-nf-3-200_3.5.0-1_amd64.deb  'https://sonic-build.azurewebsites.net/api/sonic/artifacts?branchName=master&platform=vs&target=target/debs/buster/libnl-nf-3-200_3.5.0-1_amd64.deb'
 wget -O debs/libthrift-0.11.0_0.11.0-4_amd64.deb 'https://sonic-build.azurewebsites.net/api/sonic/artifacts?branchName=master&platform=vs&target=target/debs/buster/libthrift-0.11.0_0.11.0-4_amd64.deb'
-wget -O debs/libyang_1.0.73_amd64.deb 'https://sonic-build.azurewebsites.net/api/sonic/artifacts?branchName=master&platform=vs&target=target%2Fdebs%2Fbuster%2Flibyang_1.0.73_amd64.deb'
+wget -O debs/libyang_3.7.8-2_amd64.deb 'https://sonic-build.azurewebsites.net/api/sonic/artifacts?branchName=master&platform=vs&target=target%2Fdebs%2Fbuster%2Flibyang_3.7.8-2_amd64.deb'
 wget -O debs/libswsscommon_1.0.0_amd64.deb 'https://sonic-build.azurewebsites.net/api/sonic/artifacts?branchName=master&platform=vs&target=target%2Fdebs%2Fbuster%2Flibswsscommon_1.0.0_amd64.deb'
 wget -O debs/libswsscommon-dev_1.0.0_amd64.deb 'https://sonic-build.azurewebsites.net/api/sonic/artifacts?branchName=master&platform=vs&target=target%2Fdebs%2Fbuster%2Flibswsscommon-dev_1.0.0_amd64.deb'

--- a/dependencies.conf
+++ b/dependencies.conf
@@ -9,7 +9,7 @@
                         "libnl-genl-3-200_3.5.0-1",
                         "libnl-route-3-200_3.5.0-1",
                         "libnl-nf-3-200_3.5.0-1",
-                        "libyang_1.0.73",
+                        "libyang_3.7.8-2",
                         "libswsscommon_1.0.0",
                         "libswsscommon-dev_1.0.0"
                     ]


### PR DESCRIPTION
#### Description

Port from libyang1 to libyang3. This depends on changes to sonic-buildimage.

Main Tracking ticket https://github.com/sonic-net/sonic-buildimage/issues/22385
Fixes https://github.com/sonic-net/sonic-buildimage/issues/22385

