### PR TITLE
fix file dhconnector.h not found issue

### DIFF
--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -3,6 +3,8 @@ FROM debian:bookworm
 ## Make apt-get non-interactive
 ENV DEBIAN_FRONTEND=noninteractive
 
+RUN echo "deb http://deb.debian.org/debian bookworm-backports main" >> /etc/apt/sources.list
+
 RUN apt-get update \
  && apt-get install -y \
       wget \
@@ -15,7 +17,7 @@ RUN apt-get update \
       flex \
       g++ \
       git \
-      libboost-serialization1.74-dev \
+      libboost-serialization1.83-dev \
       libhiredis-dev \
       libzmq5-dev \
       libevent-dev \

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -3,6 +3,8 @@ FROM debian:bookworm
 ## Make apt-get non-interactive
 ENV DEBIAN_FRONTEND=noninteractive
 
+RUN echo "deb http://deb.debian.org/debian bookworm-backports main" >> /etc/apt/sources.list
+
 RUN apt-get update \
  && apt-get install -y \
       vim \
@@ -12,7 +14,7 @@ RUN apt-get update \
       bridge-utils \
       net-tools \
       procps \
-      libboost-serialization1.74-dev \
+      libboost-serialization1.83-dev \
       libzmq5-dev
 
 COPY debs /debs


### PR DESCRIPTION
upgrade the libboost version to 1.83 to fix the following error:
```
make -C libcswsscommon
make[2]: Entering directory '/src/rest/libcswsscommon'
g++ -g -std=c++11 -Iinclude -I/common -I/usr/include/swss -c src/dbconnector.cpp -o src/dbconnector.o
src/dbconnector.cpp:2:10: fatal error: dbconnector.h: No such file or directory
    2 | #include <dbconnector.h>
      |          ^~~~~~~~~~~~~~~
```
This file can not be found because libswsscommon-dev_1.0.0_amd64.deb is not correctly set up, which is caused by 
```
dpkg: dependency problems prevent configuration of libswsscommon:
#9 0.480  libswsscommon depends on libboost-serialization1.83.0 (>= 1.83.0); however:
#9 0.480   Package libboost-serialization1.83.0 is not installed.
```

This issue occurred after Dec 15 2025 due to the package libboost version upgrade in sonic-swss-common repo (the submodule advance happened at the afternoon of Dec 15 2025)