### PR TITLE
Adding client cert common name(s) to the auth failure log

### DIFF
--- a/go-server-server/go/auth.go
+++ b/go-server-server/go/auth.go
@@ -42,6 +42,11 @@ func CommonNameMatch(r *http.Request) bool {
 		}
 	}
 
-	log.Printf("error: Authentication Fail! None of the common names in the client cert match any of the trusted common names")
+	commonNames := make([]string, 0)
+	for _, peercert := range r.TLS.PeerCertificates {
+		commonNames = append(commonNames, peercert.Subject.CommonName)
+	}
+	log.Printf("error: Authentication Failed! None of the common names in the client cert chain" +
+			   " matched any of the trusted common names. Client cert common names: %v", commonNames)
 	return false;
 }

--- a/go-server-server/go/auth.go
+++ b/go-server-server/go/auth.go
@@ -4,6 +4,7 @@ import (
 	"log"
 	"net/http"
 	"strings"
+	"strconv"
 )
 
 func CommonNameMatch(r *http.Request) bool {
@@ -44,7 +45,7 @@ func CommonNameMatch(r *http.Request) bool {
 
 	commonNames := make([]string, 0)
 	for _, peercert := range r.TLS.PeerCertificates {
-		commonNames = append(commonNames, peercert.Subject.CommonName)
+		commonNames = append(commonNames, strconv.Quote(peercert.Subject.CommonName))
 	}
 	log.Printf("error: Authentication Failed! None of the common names in the client cert chain" +
 			   " matched any of the trusted common names. Client cert common names: %v", commonNames)


### PR DESCRIPTION
In case of auth failure due to untrusted client cert CNs, restapi currently generates the following message:
```
Authentication Fail! None of the common names in the client cert match any of the trusted common names
```
This PR adds client cert CNs to this log. This is useful for troubleshooting purposes.
This change was tested using an untrusted client cert. The following logs were generated as expected:
```
INFO restapi#supervisord: restapi [  info ] 2026/05/29 02:36:32 request: GET /v1/state/heartbeat StateHeartbeatGet
INFO restapi#supervisord: restapi [ error ] 2026/05/29 02:36:32 Authentication Failed! None of the common names in the client cert chain matched any of the trusted common names. Client cert common names: ["client.restapi.sonic"]
INFO restapi#supervisord: restapi [  info ] 2026/05/29 02:36:32 request: return 401
INFO restapi#supervisord: restapi [ error ] 2026/05/29 02:36:32 Request ends with error message {"error":{"code":401,"message":"Authentication Fail with untrusted client cert"}}
```

**Note:** This change was tested on the 202511 branch since the master branch has an auth issue: https://github.com/sonic-net/sonic-fips/issues/86