### PR TITLE
libyang3: install libyang3 debs instead of libyang1

### DIFF
--- a/Dockerfile.common.prod
+++ b/Dockerfile.common.prod
@@ -17,7 +17,7 @@ RUN dpkg -i /debs/libhiredis0.13_0.13.3-2_amd64.deb \
  && dpkg -i /debs/libnl-3-200_3.2.27-1_amd64.deb \
  && dpkg -i /debs/libnl-genl-3-200_3.2.27-1_amd64.deb \
  && dpkg -i /debs/libnl-route-3-200_3.2.27-1_amd64.deb \
- && dpkg -i /debs/libyang_1.0.73_amd64.deb \
+ && dpkg -i /debs/libyang3_*.deb \
  && dpkg -i /debs/libswsscommon_1.0.0_amd64.deb \
  && dpkg -i /debs/libswsscommon-dev_1.0.0_amd64.deb \
  && dpkg -i /debs/sonic-rest-api_1.0.1_amd64.deb \

--- a/copy.sh
+++ b/copy.sh
@@ -8,6 +8,6 @@ wget -O debs/libnl-genl-3-200_3.5.0-1_amd64.deb  'https://sonic-build.azurewebsi
 wget -O debs/libnl-route-3-200_3.5.0-1_amd64.deb  'https://sonic-build.azurewebsites.net/api/sonic/artifacts?branchName=master&platform=vs&target=target/debs/buster/libnl-route-3-200_3.5.0-1_amd64.deb'
 wget -O debs/libnl-nf-3-200_3.5.0-1_amd64.deb  'https://sonic-build.azurewebsites.net/api/sonic/artifacts?branchName=master&platform=vs&target=target/debs/buster/libnl-nf-3-200_3.5.0-1_amd64.deb'
 wget -O debs/libthrift-0.11.0_0.11.0-4_amd64.deb 'https://sonic-build.azurewebsites.net/api/sonic/artifacts?branchName=master&platform=vs&target=target/debs/buster/libthrift-0.11.0_0.11.0-4_amd64.deb'
-wget -O debs/libyang_1.0.73_amd64.deb 'https://sonic-build.azurewebsites.net/api/sonic/artifacts?branchName=master&platform=vs&target=target%2Fdebs%2Fbuster%2Flibyang_1.0.73_amd64.deb'
+wget -O debs/libyang3_3.12.2-1_amd64.deb 'https://sonic-build.azurewebsites.net/api/sonic/artifacts?branchName=master&platform=vs&target=target%2Fdebs%2Fbookworm%2Flibyang3_3.12.2-1_amd64.deb'
 wget -O debs/libswsscommon_1.0.0_amd64.deb 'https://sonic-build.azurewebsites.net/api/sonic/artifacts?branchName=master&platform=vs&target=target%2Fdebs%2Fbuster%2Flibswsscommon_1.0.0_amd64.deb'
 wget -O debs/libswsscommon-dev_1.0.0_amd64.deb 'https://sonic-build.azurewebsites.net/api/sonic/artifacts?branchName=master&platform=vs&target=target%2Fdebs%2Fbuster%2Flibswsscommon-dev_1.0.0_amd64.deb'

--- a/dependencies.conf
+++ b/dependencies.conf
@@ -9,7 +9,7 @@
                         "libnl-genl-3-200_3.7.0-0.2+b1sonic1",
                         "libnl-route-3-200_3.7.0-0.2+b1sonic1",
                         "libnl-nf-3-200_3.7.0-0.2+b1sonic1",
-                        "libyang_1.0.73",
+                        "libyang3_3.12.2-1",
                         "libswsscommon_1.0.0",
                         "libswsscommon-dev_1.0.0"
                     ]


### PR DESCRIPTION
#### Why I did it

`sonic-buildimage` no longer builds the legacy libyang1 debs (`libyang_1.0.73`, `libyang-cpp`, `python3-yang`); it now builds only libyang3 (`libyang3`, `python3-libyang`). The prebuilt-deb references here would break once libyang1 is gone.

Part of the libyang3 migration tracked in sonic-net/sonic-buildimage#22385.

#### How I did it

- **`Dockerfile.common.prod`** — install the libyang3 runtime deb from `/debs` via a versionless glob (`libyang3_*.deb`).
- **`copy.sh`** / **`dependencies.conf`** — the `sonic-build` artifacts API requires an exact artifact filename (wildcard `target=` does not resolve), so these name the concrete `libyang3_3.12.2-1` deb, consistent with every other version-pinned dependency in these files. `copy.sh` also moves the libyang fetch to the `bookworm` artifact path, since libyang3 is not built for `buster`.

These pinned references will need a bump when libyang3's version changes — exactly as the other pinned debs in these files already do; only the Dockerfile install uses a versionless glob.

#### How to verify it

`libyang3_3.12.2-1_amd64.deb` is published on current `sonic-buildimage` master (bookworm) and downloads via the artifacts API; the Docker build installs it through the `/debs/libyang3_*.deb` glob.

#### Description for the changelog

libyang3: install libyang3 instead of libyang1 (Dockerfile glob + version-pinned artifact references).
